### PR TITLE
Add rest of V2 subclass descriptions and fix ToH V2 class features (#…

### DIFF
--- a/data/v2/kobold-press/toh/CharacterClass.json
+++ b/data/v2/kobold-press/toh/CharacterClass.json
@@ -324,7 +324,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "While most wizards who desire power over the dead focus their efforts on necromancy, there are other, rarer, paths one can choose. Gravebinders focus their efforts on safeguarding tombs and graveyards to ensure the dead remain at rest and the living remain safe from the dead. When undead rise to prey upon the living, a gravebinder hunts downs the abominations and returns them to their eternal slumber.\n\n##### Restriction: The Dead Must Rest\nWhen you choose this wizard arcane tradition, you can no longer cast spells that animate, conjure, or create undead, and, if any such spells are copied in your spellbook, they fade from the book within 24 hours, leaving blank pages where the spells were.",
+    "desc": "While most wizards who desire power over the dead focus their efforts on necromancy, there are other, rarer, paths one can choose. Gravebinders focus their efforts on safeguarding tombs and graveyards to ensure the dead remain at rest and the living remain safe from the dead. When undead rise to prey upon the living, a gravebinder hunts downs the abominations and returns them to their eternal slumber.",
     "document": "toh",
     "hit_dice": null,
     "name": "Gravebinding",
@@ -408,7 +408,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "A legionary follows the techniques of close-quarters combat developed by soldiers fighting shoulder to shoulder with their allies. This style of fighting spread far and wide, finding an honored place among the armies and mercenary companies of other races. True legionaries scoff at the image of the storybook hero standing alone against impossible odds, knowing together they can face any danger and emerge victorious.",
     "document": "toh",
     "hit_dice": null,
     "name": "Legionary",
@@ -422,7 +422,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Mercy can mean promoting healing instead of harm, but it can also mean ending suffering with a quick death. These often-contradictory ideals are the two sides of mercy. The tenets of deities who embody mercy promote ways to end bloody conflicts or deliver healing magics to those in need. While mercy for some may be benevolent, for others it is decidedly not so. More pragmatic mercy gods teach the best method to relieve the agony and torment brought on by monsters and the forces of evil is to bring about the end of that evil.",
     "document": "toh",
     "hit_dice": null,
     "name": "Mercy Domain",
@@ -436,7 +436,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "The Oath of Justice is a commitment not to the tenets of good or evil but a holy vow sworn to uphold the laws of a nation, a city, or even a tiny village. When lawlessness threatens the peace, those who swear to uphold the Oath of Justice intervene to maintain order, for if order falls to lawlessness, it is only a matter of time before all of civilization collapses into anarchy.\n\nWhile many young paladins take this oath to protect their country and the people close to them from criminals, some older adherents to this oath know that what is just is not necessarily what is right.",
     "document": "toh",
     "hit_dice": null,
     "name": "Oath of Justice",
@@ -450,7 +450,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Paladins who choose the Oath of Safeguarding spend their lives in service to others, conserving the people and places they vow to protect. They take missions to guard against assassination attempts, safely transport a person or group through treacherous lands, and stand as bastions for locations under attack. These paladins are no mere mercenaries, however, as they view their missions as sacred vows.",
     "document": "toh",
     "hit_dice": null,
     "name": "Oath of Safeguarding",
@@ -464,7 +464,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "The Oath of the Elements is taken by those paladins who have dedicated their lives to serving the awakened spirits of air, earth, fire, and water. Such paladins might also serve a genie, elemental deity, or other powerful elemental creature.",
     "document": "toh",
     "hit_dice": null,
     "name": "Oath of the Elements",
@@ -478,7 +478,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "A paladin who takes the Oath of the Guardian is sworn to defend the community. Taking the mantle of a guardian is a solemn vow to place the needs of the many before the needs of yourself and requires constant vigilance.",
     "document": "toh",
     "hit_dice": null,
     "name": "Oath of the Guardian",
@@ -492,7 +492,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Paladins who swear the Oath of the Hearth endeavor to extend the comforts of home to others, by allaying the rigors of travel or simply assuring those who grow despondent of the possibility of returning home. Ironically, paladins who follow this oath remain far from home in pursuit of their goals. Their oath reflects the welcoming warmth and light provided by the hearth, and paladins following the oath use these elements to turn away the cold or defeat enemies who employ cold as weapons.",
     "document": "toh",
     "hit_dice": null,
     "name": "Oath of the Hearth",
@@ -506,7 +506,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "After suffering an attack by a darakhul, you were infected with the dreaded—and generally fatal— darakhul fever. As you felt your life draining away and the grasp of eternal undeath clenching its cold fingers around your heart, you called out to any power that would answer your prayers. You pledged that you would do anything asked of you, if only you would be spared this fate worse than death.\n\nThat prayer was answered. The source of that answered prayer is not known, but its power flowed through you, helping you drive off the horrible unlife that was your fate. That power flows through you still. It drives you to defend innocents from the scourge of undeath, and it provides special powers for you to use in that fight.",
     "document": "toh",
     "hit_dice": null,
     "name": "Oath of the Plaguetouched",
@@ -520,7 +520,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "You have made a pact with the ancient intelligence of a primeval forest. Before the rise of human civilization, before the time of the elves, before even the dragons, there were the forests. Empires rise and fall around them, but the forests remain as a testament to nature's endurance.\n\nHowever, times are changing, and the unchecked growth of civilization threatens the green. The intelligences that imbue the antediluvian forests seek emissaries in the world that can act beyond their boughs, and one has heard your call for power. You are a guardian of the Old Wood, a questing branch issuing from a vast, slumbering intelligence sent to act on its behalf, perhaps even to excise these lesser beings from its borders.",
     "document": "toh",
     "hit_dice": null,
     "name": "Old Wood",
@@ -534,7 +534,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Barbarians who walk the Path of Booming Magnificence strive to be as lions among their people: symbols of vitality, majesty, and courage. They serve at the vanguard, leading their allies at each charge and drawing their opponents' attention away from more vulnerable members of their group. As they grow more experienced, members of this path often take on roles as leaders or in other integral positions.",
     "document": "toh",
     "hit_dice": null,
     "name": "Path of Booming Magnificence",
@@ -548,7 +548,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Devils have long been known to grant power to mortals as part of a pact or bargain. While this may take the form of unique magic or boons, those who follow the Path of Hellfire are gifted with command over the fires of the Lower Planes, which they channel for short periods to become powerful and furious fighting machines.\n\nWhile some of these barbarians are enlisted to support the devils' interests as soldiers or enforcers, some escape their devilish fates, while others still are released after their term of service.",
     "document": "toh",
     "hit_dice": null,
     "name": "Path of Hellfire",
@@ -562,7 +562,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "The first barbarians that traveled the path of mistwood were elves who expanded upon their natural gifts to become masters of the forests. Over time, members of other races who saw the need to protect and cherish the green places of the world joined and learned from them. Often these warriors haunt the woods alone, only seen when called to action by something that would despoil their home.",
     "document": "toh",
     "hit_dice": null,
     "name": "Path of Mistwood",
@@ -576,7 +576,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Few creatures embody the power and majesty of dragons. By walking the path of the dragon, you don't solely aspire to emulate these creatures—you seek to become one. The barbarians who follow this path often do so after surviving a dragon encounter or are raised in a culture that worships them. Dragons tend to have a mixed view of the barbarians who choose this path. Some dragons, in particular the metallic dragons, view such a transformation as a flattering act of admiration. Others may recognize or even fully embrace them as useful to their own ambitions. Still others view this path as embarrassing at best and insulting at worst, for what puny, two-legged creature can ever hope to come close to the natural ferocity of a dragon? When choosing this path, consider what experiences drove you to such a course. These experiences will help inform how you deal with the judgment of dragons you encounter in the world.",
     "document": "toh",
     "hit_dice": null,
     "name": "Path of the Dragon",
@@ -590,7 +590,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "In northern lands, the savage warriors charge into battle behind chanting warrior-poets. These wise men and women collect the histories, traditions, and accumulated knowledge of the people to preserve and pass on. Barbarians who follow the Path of the Herald lead their people into battle, chanting the tribe's sagas and spurring them on to new victories while honoring the glory of the past.",
     "document": "toh",
     "hit_dice": null,
     "name": "Path of the Herald",
@@ -604,7 +604,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "The barbarians who follow the Path of the Inner Eye elevate their rage beyond anger to glimpse premonitions of the future.",
     "document": "toh",
     "hit_dice": null,
     "name": "Path of the Inner Eye",
@@ -618,7 +618,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Path of Thorns barbarians use ancient techniques developed by the druids of old that enable them to grow thorns all over their body. The first barbarians of this path fought alongside these druids to defend the natural order. In the centuries since, the knowledge of these techniques has spread, allowing others access to this power.\n\nThough named for the thorns that covered the first barbarians to walk this path, current followers of this path can display thorns, spines, or boney growths while raging.",
     "document": "toh",
     "hit_dice": null,
     "name": "Path of Thorns",
@@ -632,7 +632,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "You have dedicated yourself to the study and protection of the doors, gateways, and rips in the boundaries between the physical world and the infinite planar multiverse. Stepping through portals is a sacred prayer and woe betide any who seek to misuse them.",
     "document": "toh",
     "hit_dice": null,
     "name": "Portal Domain",
@@ -646,7 +646,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Some who search for power settle on lesser gods or demon lords, others delve into deeper mysteries until they touch elder entities. These great entities build worlds, crafting mountains and species as if sculpting clay, or annihilate them utterly. Embodying creation, destruction, and the land itself, your patron is an ancient power beyond mortal understanding.\n\nPrimordials stand in opposition to the Great Old Ones, the other side of the scale that maintains the balance of reality. Your primordial patron speaks to you in the language of omens, dreams, or intuition, and may call upon you to defend the natural world, to root out the forces of the Void, or even to manipulate seemingly random people or locations for reasons known only to their unfathomable purpose. While you can't grasp the full measure of your patron's designs, as long as your bond is strong, there is nothing that can stand in your way.",
     "document": "toh",
     "hit_dice": null,
     "name": "Primordial",
@@ -660,7 +660,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Pugilists live by their fists, bare-knuckle warriors who do not hesitate to throw hands if the situation demands it. They know the intense, close, violent intimacy of melee, and they operate unapologetically in that space. Whether in fighting pits by the docks to make some extra coin, in the king's grand arena as champions of quarreling nobles, or in the employ of local merchants in need of seemingly weaponless guards, pugilists can be found in all rungs of society. Pugilists take pleasure in a battle hard won and thrill in the energy of the fight rather than in a kill. They can often be found celebrating or having drinks with a former opponent hours after the fight, regardless of the bout's winner.",
     "document": "toh",
     "hit_dice": null,
     "name": "Pugilist",
@@ -674,7 +674,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "You were a member of an order of knights dedicated to a deity of sun and light. You know that next to your deity's favor, a soldier's greatest strength is their comrades. You wield a spear, glaive, halberd, or other polearm as a piercing ray of sunlight against your enemies.",
     "document": "toh",
     "hit_dice": null,
     "name": "Radiant Pikeman",
@@ -688,7 +688,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "You are a conduit for the power that exists in sounds and vibrations, your body a living tuning fork capable of emitting, focusing, muting, and transmuting sound and sonic forms of magic. Perhaps you endured overexposure to transmutation magic, arcane thunder, or the ear-splitting cries of an androsphinx, bukavac (see *Tome of Beasts*), or avalanche screamer (see *Tome of Beasts 2*). Maybe you can trace your lineage to an ancestor who spent an extended period on a plane dominated by elemental lightning and thunder or by unceasing screams of madness; you yourself may have been born on such a cacophonous plane. Alternately, you or a forebear may have suffered prolonged exposure to the deafening thunderclaps of a bronze dragon's lair. Or you may even have been experimented on by aboleths or other maniacal spellcasters, escaping before the transformation was complete.…\n\nWhatever its source, resonant magic infuses your very existence, causing you to manifest one or more unusual characteristics. At your option, you can create a quirk or roll a d6 and consult the Resonant Body Quirks table to determine a quirk for your character.\n\n**Resonant Body Quirks (table)**\n\n| d6  | Quirk  |\r\n|---|---------|\r\n| 1 | You emit a faint hum, audible to any creature within 5 feet of you. |\r\n| 2 | In response to natural or magical thunder, your body flickers into brief transparency with the sound of each thunderclap |\r\n| 3 | Beasts with the Keen Hearing trait initially respond aggressively when you come within 30 feet of them. |\r\n| 4 | If you hold a delicate, nonmagical glass object such as a crystal wine glass for longer than one round, the object shatters. |\r\n| 5 | Every time you speak, your voice randomly changes in pitch, tone, and/or resonance, so that you never sound quite the same. |\r\n| 6 | When another living creature touches you, you emit a brief, faint tone like a chime, the volume of which increases with the force of the touch. |",
     "document": "toh",
     "hit_dice": null,
     "name": "Resonant Body",
@@ -702,7 +702,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Rifthoppers are the living embodiment of wanderlust. The yearn to travel and witness unseen vistas burns in them and manifests in their ability to move nearly at the speed of thought. The origin of the rifthoppers' powers remains a mystery, as they refuse to stay in one place long enough to be studied extensively. Given the lack of empirical evidence, many scholars have hypothesized that rifthoppers absorb energy from the world itself, typically through an innate connection with ley lines or with areas where the borders between planes are thin, and can use it to alter their own magic.\n  Adventuring rifthoppers often concern themselves with investigating mysterious portals to unknown locations, researching ley lines and other mystic phenomena, or seeking out and stopping spatial and temporal disturbances.",
     "document": "toh",
     "hit_dice": null,
     "name": "Rifthopper",
@@ -716,7 +716,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "You focus as much on identifying the weak points of structures as on the weak points of creatures. Sappers are deployed with the soldiery to dig trenches, build bridges, and breach defenses. When troops move into a heavily defended area, it's your job to make it happen as efficiently as possible.",
     "document": "toh",
     "hit_dice": null,
     "name": "Sapper",
@@ -730,7 +730,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Liminal spaces are spaces on the boundary, at the edge between what's real and what's unreal. A liminal space can be neither here nor there, and yet be both *here and there* at the same time. Stories of liminal spaces are common across cultures, though their true nature often isn't recognized by the uninitiated: the stranger who appears suddenly at a lonely crossroads, the troll that snatches at unwary travelers from a hiding spot beneath a bridge where no such hiding spot exists, the strangely familiar yet unsettlingly different scene that's sometimes glimpsed in a looking glass.\n\nThese are only the most obvious encounters with liminal spaces! Most liminalities are more easily overlooked, being as unconscious as the heartbeat between waking and sleeping, as fleeting as drawing in breath as an apprentice and exhaling it as a master, or as unassumingly familiar—and as fraught with potential—as a doorway that's crossed a hundred times without incident.\n\nThose who specialize in liminal magic are known as liminists. They've learned to tap into the mysticism at the heart of spaces between spaces and to bend the possibilities inherent in transitional moments to their own ends. Like filaments of a dream, strands of liminality can be woven into forms new and wondrous—or strange and terrifying.",
     "document": "toh",
     "hit_dice": null,
     "name": "School of Liminality",
@@ -744,7 +744,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "You embody the deadly, secretive, and mesmerizing nature of serpents. Others tremble at your majesty. You practice the stealth and envenomed attacks that give serpents their dreaded reputation, but you also learn the shedding of skin that has made snakes into symbols of medicine.",
     "document": "toh",
     "hit_dice": null,
     "name": "Serpent Domain",
@@ -758,7 +758,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "The shadow domain embraces the darkness that surrounds all things and manipulates the transitory gray that separates light from dark. Shadow domain clerics walk a subtle path, frequently changing allegiances and preferring to operate unseen.",
     "document": "toh",
     "hit_dice": null,
     "name": "Shadow Domain",
@@ -772,7 +772,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "The transport of goods, creatures, and even people can be a lucrative business, particularly if you know how to avoid expensive import and export taxes, bridge, highway, and port tolls, and other legal requirements. Exotic poisons from far-off locales, banned or cursed magic items, and illicit drugs or bootleg liquor all fetch a high price on the black market. Thieves-guilds, pirates, and criminal kingpins pay well to those who can avoid law enforcement when moving stolen goods, provide safe channels of communication, break associates free from jail cells or dungeons, or deliver supplies past guards. You've become adept at all of these things, perhaps even having developed a network of contacts as a criminal, noble, con artist, or sailor during an earlier part of your life.",
     "document": "toh",
     "hit_dice": null,
     "name": "Smuggler",
@@ -786,7 +786,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Like the serpents they adore, snake speakers are highly adaptable hunters. Snakes are common throughout the world, and people who need to travel through snake-filled jungles often retain a snake speaker guide, trusting the guide to protect them from scaly poisoners.",
     "document": "toh",
     "hit_dice": null,
     "name": "Snake Speaker",
@@ -800,7 +800,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "In the eternal war between good and evil, between light and darkness, between life and death, there are many types of participants on each side. Soulspies are agents of the divine who lurk in the shadows, taking a less-visible role in the fight. Occasionally, they aid other agents of their deities, but most often they locate and manage or eliminate threats to their deities that more scrupulous agents might be unwilling or unable to handle.",
     "document": "toh",
     "hit_dice": null,
     "name": "Soulspy",
@@ -814,7 +814,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "The alseid have long defended the limits of their forest homes. These warriors can make a dizzying variety of ranged and melee attacks in quick succession, using ancient magic to flash across the battlefield.\n\n##### Restriction: Alseid\nYou can choose this archetype only if you are an alseid.",
     "document": "toh",
     "hit_dice": null,
     "name": "Spear of the Weald",
@@ -828,7 +828,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Some wizards pride themselves on being spell artisans, carefully sculpting the magical energy of spells like smiths sculpt iron. Focusing on the artistry inherent in spellcasting, these wizards learn to tap the magical energy of spells and manipulate that energy to amplify or modify spells like no other arcane practitioners.",
     "document": "toh",
     "hit_dice": null,
     "name": "Spellsmith",
@@ -842,7 +842,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "One of the most omnipresent elements in the atmosphere is practically invisible and often ignored: spores. Plants of all varieties, fungal sentient life forms like mushroomfolk, and even animals emit these tiny pieces of life. You've always had an affinity for the natural world, and your innate magic is carried within the power of these omnipresent spores.\n\nSpore sorcerers are regularly found among the mushroomfolk and derro who grow large gardens of fungi deep beneath the surface of the world. Spore sorcerers can also be found in any area with an abundance of plant life, such as forests, swamps, and deep jungles.",
     "document": "toh",
     "hit_dice": null,
     "name": "Spore Sorcery",
@@ -856,7 +856,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "There are warriors who move so quickly that they seem to stop time, then there are those who actually alter time with their attacks. The timeblade augments physical attacks by manipulating temporal powers and eventually learns to step outside time itself.",
     "document": "toh",
     "hit_dice": null,
     "name": "Timeblade",
@@ -870,7 +870,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "For untold ages, the dwarves have paid in blood to keep their subterranean homes safe. The keystone to the defense of the dwarven citadels are the tunnel watchers, warriors trained in the tight, uneven paths beneath the surface of the world. While the techniques of the tunnel watchers originated with the dwarves, others see the value in such specialization. Tunnel watchers can thus be found throughout the mountainous regions of the world.",
     "document": "toh",
     "hit_dice": null,
     "name": "Tunnel Watcher",
@@ -884,7 +884,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Though most rogues prefer ambushing their opponents from the shadows, erina rogues ambush their opponents from below. These Underfoot use druidic magic and their natural aptitude for burrowing to defend their forest homes. The Underfoot are an elite order of burrow warriors in every erina colony. Using a combination of guerilla attacks and druidic magic, they are a force to be reckoned with, diving into fights nose-forward.",
     "document": "toh",
     "hit_dice": null,
     "name": "Underfoot",
@@ -898,7 +898,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "You exemplify the cunning, stealth, and invasiveness of vermin (rodents, scorpions, spiders, ants, and other insects). As your dedication to this domain grows in strength, you realize a simple truth: vermin are everywhere, and you are legion.",
     "document": "toh",
     "hit_dice": null,
     "name": "Vermin Domain",
@@ -912,7 +912,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "A barren landscape wracked by chaotic magics, crawling with strange monstrosities and twisted aberrations that warp the minds of those who lay eyes upon them … you have learned to traverse these wastes and face these creatures without flinching. You patrol its boundaries and stride unseen through its harsh landscape, evading danger and protecting those who find themselves at the mercy of the arcana-laced wilds and eldritch horrors.",
     "document": "toh",
     "hit_dice": null,
     "name": "Wasteland Strider",
@@ -926,7 +926,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Eldritch power and residual magical energy left over from a horrific arcane war is drawn to you as a lodestone is drawn to iron. Perhaps this attraction is due to a pact one of your ancestors made with an ancient eldritch horror. Perhaps it is an unfortunate twist of circumstance. Regardless, your physiology is in a constant state of transformation as a result of your condition. Some sorcerers who arise from magical wastelands embrace their body's modifications, others take to adventuring to find a cure for what they see as their affliction, while others still seek to make a mark on the world before oblivion claims them.",
     "document": "toh",
     "hit_dice": null,
     "name": "Wastelander",
@@ -940,7 +940,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "The monks of Concordant Motion follow a tradition developed and honed by various goblin and kobold clans that favored tactics involving swarming warriors. The tradition combines tactical disciplines designed to encourage groups to work as one unit with practical strategies for enhancing allies. Where many warrior-monks view ki as a power best kept within, the Way of Concordant Motion teaches its followers to project their ki into their allies through ascetic meditation and mental exercises. Followers of this tradition value teamwork and promote functioning as a cohesive whole above any search for triumph or glory.",
     "document": "toh",
     "hit_dice": null,
     "name": "Way of Concordant Motion",
@@ -954,7 +954,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "You have studied at a monastery devoted to dragonkind. Warriors trained in these places adapt their fighting styles to match the dragons they hold in such esteem. They are respected and feared by students of other traditions. Once they are trained, followers of this Way travel far and wide, rarely settling in one place for long.",
     "document": "toh",
     "hit_dice": null,
     "name": "Way of the Dragon",
@@ -968,7 +968,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Like their namesake, monks of the Way of the Humble Elephant are respectful and accommodating. A large part of their training involves traveling through their home region and assisting local farmers and common folk with problems ranging from rebuilding burned homes to dispatching troublesome bandits. In areas where their Way is known, adherents are welcomed into the community and their needs are seen to in exchange for the host of benefits their presence brings to the community.",
     "document": "toh",
     "hit_dice": null,
     "name": "Way of the Humble Elephant",
@@ -982,7 +982,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Monks who follow the Way of the Still Waters are like placid mountain lakes; they are still and calm until some outside force disrupts them and forces a reaction. Many adherents live a pacifistic lifestyle and never seek conflict. When strife finds them, though, they deal with it in a swift and decisive use of power and grace.",
     "document": "toh",
     "hit_dice": null,
     "name": "Way of the Still Waters",
@@ -996,7 +996,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Monks who practice the Way of the Tipsy Monkey lurch and waddle across the battlefield, seeming to be too intoxicated to comport themselves. Their school of fighting is typified by its low-standing stance, periods of swaying in place punctuated with bursts of wild, staggering movement, and the disorienting manner in which they seem to never be in the place they appear to be standing.\n\nDespite the name of their style, monks of this Way often abstain from drinking alcohol, though they are not prohibited from doing so. Many do, however, display traits of their patron monkey in their love of jests and their easy laughter, even in the most fraught situations.",
     "document": "toh",
     "hit_dice": null,
     "name": "Way of the Tipsy Monkey",
@@ -1010,7 +1010,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "The inner peace of contemplation, the artistry of focused breathing, and the calm awareness which leads to pinpoint accuracy all contribute to the Way of the Unerring Arrow. Some are dedicated soldiers, others walk the path of a wandering warrior-mendicant, but all of them hone their art of self-control, spirituality, and the martial arts, combining unarmed combat with archery. Select this tradition if you want to play a character who is as comfortable trading kicks and blows as they are with snatching an arrow from the air and firing it back in a single motion.",
     "document": "toh",
     "hit_dice": null,
     "name": "Way of the Unerring Arrow",
@@ -1024,7 +1024,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Monks of the Wildcat train relentlessly to incorporate speed, acrobatics, and precision strikes to exert control over the field of battle and foes alike. They learn techniques that emulate the grace and agility of felines, including reflexively avoiding blows and bounding between opponents with ease. Embodying the Way of the Wildcat requires intense devotion, endless practice, and no small amount of daring.",
     "document": "toh",
     "hit_dice": null,
     "name": "Way of the Wildcat",
@@ -1038,7 +1038,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "You have dedicated yourself to the service of the primordial winds. In their service, you are the gentle zephyr brushing away adversity or the vengeful storm scouring the stones from the mountainside.",
     "document": "toh",
     "hit_dice": null,
     "name": "Wind Domain",
@@ -1052,7 +1052,7 @@
 {
   "fields": {
     "caster_type": null,
-    "desc": "",
+    "desc": "Your patron is probability itself, the personified wellspring of chance as embodied by chosen deities, entities, and eldritch beings across the planes. By binding yourself to the Wyrdweaver, you live by the roll of the dice and the flip of the coin, delighting in the randomness of life and the thrill of new experiences. You might find yourself driven to invade a lich's keep to ask it about its favorite song, or you might leap onto a dragon's back to have the right to call yourself a dragonrider. Life with a pact-bond to your patron might not be long, but it will be exciting.",
     "document": "toh",
     "hit_dice": null,
     "name": "Wyrdweaver",

--- a/data/v2/kobold-press/toh/ClassFeature.json
+++ b/data/v2/kobold-press/toh/ClassFeature.json
@@ -1421,6 +1421,17 @@
 },
 {
   "fields": {
+    "desc": "Cleric Level | Spells                                 |\r\n|--------------|----------------------------------------|\r\n| 1st          | *bloodbound*, *illuminate spoor*       |\r\n| 3rd          | *instant snare*, *mark prey*           |\r\n| 5th          | *going in circles*, *tracer*           |\r\n| 7th          | *heart-seeking arrow*, *hunting stand* |\r\n| 9th          | *harrying hounds*, *maim*              |",
+    "document": "toh",
+    "name": "Hunt Domain Spells",
+    "parent": "toh_hunt-domain"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "toh_hunt-domain_hunt-domain-spells"
+},
+
+{
+  "fields": {
     "desc": "Starting at 6th level, when an ally within 30 feet of you makes a weapon attack roll against a creature you attacked within this round, you can use your reaction to grant that ally advantage on the attack roll.",
     "document": "toh",
     "name": "Pack Hunter",
@@ -1488,6 +1499,16 @@
   },
   "model": "api_v2.classfeature",
   "pk": "toh_hunter-in-darkness_the-hunter-in-darkness-and-your-pact-boons"
+},
+{
+  "fields": {
+    "desc": "When you choose this archetype at 3rd level, you gain proficiency in the Insight, Nature, or Survival skill (your choice).",
+    "document": "toh",
+    "name": "Bonus Proficiency",
+    "parent": "toh_legionary"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "toh_legionary_bonus-proficiency"
 },
 {
   "fields": {
@@ -1598,6 +1619,16 @@
   },
   "model": "api_v2.classfeature",
   "pk": "toh_mercy-domain_hand-of-grace-and-execution"
+},
+{
+  "fields": {
+    "desc": "Cleric Level | Spells                              |\r\n|--------------|-------------------------------------|\r\n| 1st          | *divine favor*, *healing word*      |\r\n| 3rd          | *aid*, *ray of enfeeblement*        |\r\n| 5th          | *bardo*, *revivify*                 |\r\n| 7th          | *death ward*, *sacrificial healing* |\r\n| 9th          | *antilife shell*, *raise dead*      |",
+    "document": "toh",
+    "name": "Mercy Domain Spells",
+    "parent": "toh_mercy-domain"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "toh_mercy-domain_mercy-domain-spells"
 },
 {
   "fields": {
@@ -2391,6 +2422,16 @@
 },
 {
   "fields": {
+    "desc": "You gain domain spells at the cleric levels listed in the Portal Domain Spells table. See the Divine Domain class feature for how domain spells work.\n\n**Portal Domain Spells**\n\n| Cleric Level | Spells                                    |\r\n|--------------|-------------------------------------------|\r\n| 1st          | *adjust position*, *expeditious retreat*  |\r\n| 3rd          | *glyph of shifting*, *misty step*         |\r\n| 5th          | *dimensional shove*, *portal jaunt*       |\r\n| 7th          | *dimension door*, *reposition*            |\r\n| 9th          | *pierce the veil*, *teleportation circle* |",
+    "document": "toh",
+    "name": "Domain Spells",
+    "parent": "toh_portal-domain"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "toh_portal-domain_domain-spells"
+},
+{
+  "fields": {
     "desc": "At 1st level, you learn to forge a bond between yourself and another creature. At the end of a short or long rest, you can touch one willing creature, establishing a magical bond between you. While bonded to a creature, you know the direction to the creature, though not its exact location, as long as you are both on the same plane of existence. As an action, you can teleport the bonded creature to an unoccupied space within 5 feet of you or to the nearest unoccupied space, provided the bonded creature is willing and within a number of miles of you equal to your proficiency bonus. Alternatively, you can teleport yourself to an unoccupied space within 5 feet of the bonded creature.\n  Once you teleport a creature in this way, you can't use this feature again until you finish a long rest. You can have only one bonded creature at a time. If you bond yourself to a new creature, the bond on the previous creature ends. Otherwise, the bond lasts until you die or dismiss it as an action.",
     "document": "toh",
     "name": "Portal Bond",
@@ -2851,6 +2892,16 @@
 },
 {
   "fields": {
+    "desc": "Cleric Level | Spells                                              |\r\n|--------------|-----------------------------------------------------|\r\n| 1st          | *charm person*, *find familiar* (snakes only)       |\r\n| 3rd          | *enthrall*, *protection from poison*                |\r\n| 5th          | *conjure animals* (snakes only), *hypnotic pattern* |\r\n| 7th          | *freedom of movement*, *polymorph* (snakes only)    |\r\n| 9th          | *dominate person*, *mislead*                        |",
+    "document": "toh",
+    "name": "Serpent Domain Spells",
+    "parent": "toh_serpent-domain"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "toh_serpent-domain_serpent-domain-spells"
+},
+{
+  "fields": {
     "desc": "Starting at 6th level, you are immune to the poisoned condition and have resistance to poison damage.",
     "document": "toh",
     "name": "Serpent's Blood",
@@ -2928,6 +2979,16 @@
   },
   "model": "api_v2.classfeature",
   "pk": "toh_shadow-domain_potent-spellcasting"
+},
+{
+  "fields": {
+    "desc": "Cleric Level | Spells                                    |\r\n|--------------|-------------------------------------------|\r\n| 1st          | *bane*, *false life*                      |\r\n| 3rd          | *blindness/deafness*, *darkness*          |\r\n| 5th          | *blink*, *fear*                           |\r\n| 7th          | *black tentacles*, *greater invisibility* |\r\n| 9th          | *cone of cold*, *dream*                   |",
+    "document": "toh",
+    "name": "Shadow Domain Spells",
+    "parent": "toh_shadow-domain"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "toh_shadow-domain_shadow-domain-spells"
 },
 {
   "fields": {
@@ -3051,16 +3112,6 @@
 },
 {
   "fields": {
-    "desc": "You learn three cantrips of your choice from the cleric spell list. You learn another cleric cantrip of your choice at 10th level.\n\n**Soulspy Spellcasting**\n| Rouge Level  | Cantrips Known | Spells Known | 1st | 2nd | 3rd | 4th | \n|--------------|----------------|--------------|-----|-----|-----|-----| \n| 3rd          | 3              | 3              | 2   | -   | -   | -   | \n| 4th          | 3              | 4              | 3   | -   | -   | -   | \n| 5th          | 3              | 4              | 3   | -   | -   | -   | \n| 6th          | 3              | 4              | 3   | -   | -   | -   | \n| 7th          | 3              | 5              | 4   | 2   | -   | -   | \n| 8th          | 3              | 6              | 4   | 2   | -   | -   | \n| 9th          | 3              | 6              | 4   | 2   | -   | -   | \n| 10th         | 4              | 7              | 4   | 3   | -   | -   | \n| 11th         | 4              | 8              | 4   | 3   | -   | -   | \n| 12th         | 4              | 8              | 4   | 3   | -   | -   | \n| 13th         | 4              | 9              | 4   | 3   | 2   | -   | \n| 14th         | 4              | 10             | 4   | 3   | 2   | -   | \n| 15th         | 4              | 10             | 4   | 3   | 2   | -   | \n| 16th         | 4              | 11             | 4   | 3   | 3   | -   | \n| 17th         | 4              | 11             | 4   | 3   | 3   | -   | \n| 18th         | 4              | 11             | 4   | 3   | 3   | -   | \n| 19th         | 4              | 12             | 4   | 3   | 3   | 1   | \n| 20th         | 4              | 13             | 4   | 3   | 3   | 1   |",
-    "document": "toh",
-    "name": "Cantrips",
-    "parent": "toh_soulspy"
-  },
-  "model": "api_v2.classfeature",
-  "pk": "toh_soulspy_cantrips"
-},
-{
-  "fields": {
     "desc": "Starting at 3rd level, you can use an action to create a symbol of your deity that hovers within 5 feet of you. The symbol is a Tiny object that is visible but invulnerable and intangible, and it lasts for 1 minute, until you die, or until you dismiss it (no action required). While this symbol is active, you gain the following benefits: \n* Your Divine Symbol functions as a spellcasting focus for your cleric spells. \n* As a bonus action, you can turn the symbol into thieves- tools, which you can use to pick locks, disarm traps, or any other activities that would normally require such tools. While your Divine Symbol is functioning in this way, it loses all other properties listed here. You can change it from thieves- tools back to its symbol form as a bonus action. \n* The symbol sheds bright light in a 10-foot radius and dim light for an additional 10 feet. You can extinguish or restore the light as a bonus action. When you extinguish the symbol-s light, you can also snuff out one candle, torch, or other nonmagical light source within 10 feet of you. \n* When you create this symbol, and as an action on each of your turns while the symbol is active, you can force the symbol to shoot divine energy at a creature you can see within 30 feet of you. Make a ranged spell attack. On a hit, the target takes 1d8 radiant or necrotic damage (your choice). When you reach certain levels in this class, the symbol-s damage increases: at 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
     "document": "toh",
     "name": "Divine Symbol",
@@ -3091,43 +3142,13 @@
 },
 {
   "fields": {
-    "desc": "The Soulspy Spellcasting table shows how many spell slots you have to cast your cleric spells of 1st level and higher. To cast one of these spells, you must expend one of these slots at the spell-s level or higher. You regain all expended spell slots when you finish a long rest.\n\nFor example, if you know the 1st-level spell *inflict wounds* and have a 1st-level and a 2nd-level spell slot available, you can cast *inflict wounds* using either slot.",
-    "document": "toh",
-    "name": "Spell Slots",
-    "parent": "toh_soulspy"
-  },
-  "model": "api_v2.classfeature",
-  "pk": "toh_soulspy_spell-slots"
-},
-{
-  "fields": {
-    "desc": "When you reach 3rd level, you gain the ability to cast spells drawn from the magic of a divine entity.",
+    "desc": "When you reach 3rd level, you gain the ability to cast spells drawn from the magic of a divine entity.\n\n##### Cantrips\nYou learn three cantrips of your choice from the cleric spell list. You learn another cleric cantrip of your choice at 10th level.\n\n**Soulspy Spellcasting**\n\n| Rouge Level  | Cantrips Known | Spells Known | 1st | 2nd | 3rd | 4th |\r\n|--------------|----------------|--------------|-----|-----|-----|-----|\r\n| 3rd          | 3              | 3              | 2   | -   | -   | -   |\r\n| 4th          | 3              | 4              | 3   | -   | -   | -   |\r\n| 5th          | 3              | 4              | 3   | -   | -   | -   |\r\n| 6th          | 3              | 4              | 3   | -   | -   | -   |\r\n| 7th          | 3              | 5              | 4   | 2   | -   | -   |\r\n| 8th          | 3              | 6              | 4   | 2   | -   | -   |\r\n| 9th          | 3              | 6              | 4   | 2   | -   | -   |\r\n| 10th         | 4              | 7              | 4   | 3   | -   | -   |\r\n| 11th         | 4              | 8              | 4   | 3   | -   | -   |\r\n| 12th         | 4              | 8              | 4   | 3   | -   | -   |\r\n| 13th         | 4              | 9              | 4   | 3   | 2   | -   |\r\n| 14th         | 4              | 10             | 4   | 3   | 2   | -   |\r\n| 15th         | 4              | 10             | 4   | 3   | 2   | -   |\r\n| 16th         | 4              | 11             | 4   | 3   | 3   | -   |\r\n| 17th         | 4              | 11             | 4   | 3   | 3   | -   |\r\n| 18th         | 4              | 11             | 4   | 3   | 3   | -   |\r\n| 19th         | 4              | 12             | 4   | 3   | 3   | 1   |\r\n| 20th         | 4              | 13             | 4   | 3   | 3   | 1   |\n\n##### Spell Slots\nThe Soulspy Spellcasting table shows how many spell slots you have to cast your cleric spells of 1st level and higher. To cast one of these spells, you must expend one of these slots at the spell-s level or higher. You regain all expended spell slots when you finish a long rest.\n\nFor example, if you know the 1st-level spell *inflict wounds* and have a 1st-level and a 2nd-level spell slot available, you can cast *inflict wounds* using either slot.\n\n##### Spells Known of 1st-Level and Higher\nYou know three 1st-level cleric spells of your choice, two of which you must choose from the abjuration and necromancy spells on the cleric spell list. The Spells Known column of the Soulspy Spellcasting table shows when you learn more cleric spells of 1st level or higher. Each of these spells must be an abjuration or necromancy spell and must be of a level for which you have spell slots. The spells you learn at 8th, 14th, and 20th level can be from any school of magic.\n  When you gain a level in this class, you can choose one of the cleric spells you know and replace it with another spell from the cleric spell list. The new spell must be of a level for which you have spell slots, and it must be an abjuration or necromancy spell, unless you-re replacing the spell you gained at 3rd, 8th, 14th, or 20th level.\n\n##### Spellcasting Ability\nWisdom is your spellcasting ability for your cleric spells. You learn your spells through meditation and prayer to the powerful forces that guide your actions. You use your Wisdom whenever a spell refers to your spellcasting ability. In addition, you use your Wisdom modifier when setting the saving throw DC for a cleric spell you cast and when making an attack roll with one.\n\n**Spell save DC** = 8 + your proficiency bonus + your Wisdom modifier\n\n**Spell attack modifier** = your proficiency bonus + your Wisdom modifier",
     "document": "toh",
     "name": "Spellcasting",
     "parent": "toh_soulspy"
   },
   "model": "api_v2.classfeature",
   "pk": "toh_soulspy_spellcasting"
-},
-{
-  "fields": {
-    "desc": "Wisdom is your spellcasting ability for your cleric spells. You learn your spells through meditation and prayer to the powerful forces that guide your actions. You use your Wisdom whenever a spell refers to your spellcasting ability. In addition, you use your Wisdom modifier when setting the saving throw DC for a cleric spell you cast and when making an attack roll with one.\n\n**Spell save DC** = 8 + your proficiency bonus + your Wisdom modifier\n\n**Spell attack modifier** = your proficiency bonus + your Wisdom modifier",
-    "document": "toh",
-    "name": "Spellcasting Ability",
-    "parent": "toh_soulspy"
-  },
-  "model": "api_v2.classfeature",
-  "pk": "toh_soulspy_spellcasting-ability"
-},
-{
-  "fields": {
-    "desc": "You know three 1st-level cleric spells of your choice, two of which you must choose from the abjuration and necromancy spells on the cleric spell list. The Spells Known column of the Soulspy Spellcasting table shows when you learn more cleric spells of 1st level or higher. Each of these spells must be an abjuration or necromancy spell and must be of a level for which you have spell slots. The spells you learn at 8th, 14th, and 20th level can be from any school of magic.\n  When you gain a level in this class, you can choose one of the cleric spells you know and replace it with another spell from the cleric spell list. The new spell must be of a level for which you have spell slots, and it must be an abjuration or necromancy spell, unless you-re replacing the spell you gained at 3rd, 8th, 14th, or 20th level.",
-    "document": "toh",
-    "name": "Spells Known of 1st-Level and Higher",
-    "parent": "toh_soulspy"
-  },
-  "model": "api_v2.classfeature",
-  "pk": "toh_soulspy_spells-known-of-1st-level-and-higher"
 },
 {
   "fields": {
@@ -3558,6 +3579,16 @@
   },
   "model": "api_v2.classfeature",
   "pk": "toh_vermin-domain_the-unseen"
+},
+{
+  "fields": {
+    "desc": "Cleric Level | Spells  |\r\n|--------------|---------|\r\n| 1st          | *detect poison and disease*, *speak with animals* (vermin only)  |\r\n| 3rd          | *spider climb*, *web*  |\r\n| 5th          | *conjure animals* (vermin only), *fear*  |\r\n| 7th          | *dominate beast* (vermin only), *giant insect*  |\r\n| 9th          | *contagion*, *insect plague*  |",
+    "document": "toh",
+    "name": "Vermin Domain Spells",
+    "parent": "toh_vermin-domain"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "toh_vermin-domain_vermin-domain-spells"
 },
 {
   "fields": {
@@ -4038,6 +4069,16 @@
   },
   "model": "api_v2.classfeature",
   "pk": "toh_wind-domain_stormshield"
+},
+{
+  "fields": {
+    "desc": "Cleric Level | Spells                                                        |\r\n|--------------|---------------------------------------------------------------|\r\n| 1st          | *feather fall*, *thunderwave*                                 |\r\n| 3rd          | *gust of wind*, *misty step*                                  |\r\n| 5th          | *fly*, *wind wall*                                            |\r\n| 7th          | *conjure minor elementals* (air only), *freedom of movement*  |\r\n| 9th          | *cloudkill*, *conjure elemental* (air only)                   |",
+    "document": "toh",
+    "name": "Wind Domain Spells",
+    "parent": "toh_wind-domain"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "toh_wind-domain_wind-domain-spells"
 },
 {
   "fields": {

--- a/data/v2/kobold-press/toh/ClassFeatureItem.json
+++ b/data/v2/kobold-press/toh/ClassFeatureItem.json
@@ -1383,6 +1383,16 @@
   "fields": {
     "column_value": null,
     "detail": null,
+    "level": 1,
+    "parent": "toh_hunt-domain_hunt-domain-spells"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "toh_hunt-domain_hunt-domain-spells_1"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
     "level": 6,
     "parent": "toh_hunt-domain_pack-hunter"
   },
@@ -1438,6 +1448,16 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "toh_hunter-in-darkness_the-hunter-in-darkness-and-your-pact-boons_3"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "toh_legionary_bonus-proficiency"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "toh_legionary_bonus-proficiency_3"
 },
 {
   "fields": {
@@ -1548,6 +1568,16 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "toh_mercy-domain_hand-of-grace-and-execution_17"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 1,
+    "parent": "toh_mercy-domain_mercy-domain-spells"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "toh_mercy-domain_mercy-domain-spells_1"
 },
 {
   "fields": {
@@ -2184,6 +2214,16 @@
     "column_value": null,
     "detail": null,
     "level": 1,
+    "parent": "toh_portal-domain_domain-spells"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "toh_portal-domain_domain-spells_1"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 1,
     "parent": "toh_portal-domain_portal-bond"
   },
   "model": "api_v2.classfeatureitem",
@@ -2633,6 +2673,16 @@
   "fields": {
     "column_value": null,
     "detail": null,
+    "level": 1,
+    "parent": "toh_serpent-domain_serpent-domain-spells"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "toh_serpent-domain_serpent-domain-spells_1"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
     "level": 6,
     "parent": "toh_serpent-domain_serpents-blood"
   },
@@ -2708,6 +2758,16 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "toh_shadow-domain_potent-spellcasting_8"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 1,
+    "parent": "toh_shadow-domain_shadow-domain-spells"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "toh_shadow-domain_shadow-domain-spells_1"
 },
 {
   "fields": {
@@ -2833,16 +2893,6 @@
   "fields": {
     "column_value": null,
     "detail": null,
-    "level": 10,
-    "parent": "toh_soulspy_cantrips"
-  },
-  "model": "api_v2.classfeatureitem",
-  "pk": "toh_soulspy_cantrips_10"
-},
-{
-  "fields": {
-    "column_value": null,
-    "detail": null,
     "level": 3,
     "parent": "toh_soulspy_divine-symbol"
   },
@@ -2873,31 +2923,11 @@
   "fields": {
     "column_value": null,
     "detail": null,
-    "level": 1,
-    "parent": "toh_soulspy_spell-slots"
-  },
-  "model": "api_v2.classfeatureitem",
-  "pk": "toh_soulspy_spell-slots_1"
-},
-{
-  "fields": {
-    "column_value": null,
-    "detail": null,
     "level": 3,
     "parent": "toh_soulspy_spellcasting"
   },
   "model": "api_v2.classfeatureitem",
   "pk": "toh_soulspy_spellcasting_3"
-},
-{
-  "fields": {
-    "column_value": null,
-    "detail": null,
-    "level": 1,
-    "parent": "toh_soulspy_spells-known-of-1st-level-and-higher"
-  },
-  "model": "api_v2.classfeatureitem",
-  "pk": "toh_soulspy_spells-known-of-1st-level-and-higher_1"
 },
 {
   "fields": {
@@ -3298,6 +3328,16 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "toh_vermin-domain_the-unseen_1"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 1,
+    "parent": "toh_vermin-domain_vermin-domain-spells"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "toh_vermin-domain_vermin-domain-spells_1"
 },
 {
   "fields": {
@@ -3778,6 +3818,16 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "toh_wind-domain_stormshield_6"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 1,
+    "parent": "toh_wind-domain_wind-domain-spells"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "toh_wind-domain_wind-domain-spells_1"
 },
 {
   "fields": {

--- a/data/v2/open5e/open5e/CharacterClass.json
+++ b/data/v2/open5e/open5e/CharacterClass.json
@@ -128,6 +128,20 @@
 {
   "fields": {
     "caster_type": null,
+    "desc": "*Compare to the core book’s school of Necromancy*\n\nNothing fills a mundane with fear quite like a necromancer. Sure, a fireball is scary, but these masters of the dark arts deal with the forces of life and death like they were mere playthings. They can drain life from the living and force the dead to heed their beck and call. Practitioners of the necromantic arts have a reputation for evil, but they are not universally so (even if they tend to always be at least a little dark and edgy). Necromancers can also be heroic forces for good in the world, though they may need to have some flexible morals when it comes to sourcing the raw materials for their undead minions.",
+    "document": "open5e",
+    "hit_dice": null,
+    "name": "School of Necrotic Arts",
+    "primary_abilities": [],
+    "saving_throws": [],
+    "subclass_of": "srd_wizard"
+  },
+  "model": "api_v2.characterclass",
+  "pk": "open5e_school-of-necrotic-arts"
+},
+{
+  "fields": {
+    "caster_type": null,
     "desc": "*Compare to the core book's Tempest Domain*\n\nNothing inspires fear in mortals quite like a raging storm. This domain encompasses deities such as Enlil, Indra, Raijin, Taranis, Zeus, and Zojz. Many of these are the rulers of their respective pantheons, wielding the thunderbolt as a symbol of divine might. Most reside in the sky, but the domain also includes lords of the sea (like Donbettyr) and even the occasional chthonic fire deity (such as Pele). They can be benevolent (like Tlaloc), nourishing crops with life-giving rain; they can also be martial deities (such as Perun and Thor), splitting oaks with axes of lightning or battering their foes with thunderous hammers; and some (like Tiamat) are fearsome destroyers, spoken of only in whispers so as to avoid drawing their malevolent attention. Whatever their character, the awesome power of their wrath cannot be denied.",
     "document": "open5e",
     "hit_dice": null,

--- a/data/v2/open5e/open5e/ClassFeature.json
+++ b/data/v2/open5e/open5e/ClassFeature.json
@@ -491,6 +491,56 @@
 },
 {
   "fields": {
+    "desc": "Beginning at 14th level, you are able to take control of the undead, even if you did not create them with your own magic. You can use your action to target an undead creature within 60 feet of you that you can see. If the target fails a Charisma saving throw versus your wizard spell save DC, its attitude towards you becomes friendly and it obeys any commands you issue it until the next time you use this feature. If the target succeeds its saving throw, it becomes permanently immune to this effect.\n\nIf the undead creature’s Intelligence score is 8 or higher, it makes the saving throw to resist control with advantage. If its Intelligence score is 12 or higher and it fails its first saving throw, it can repeat the save to break free once every hour it remains under your control.",
+    "document": "open5e",
+    "name": "Control Undead",
+    "parent": "open5e_school-of-necrotic-arts"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "open5e_school-of-necrotic-arts_control-undead"
+},
+{
+  "fields": {
+    "desc": "Already at 2nd level, you become adept at harvesting the animus from living beings killed by your spells. Up to once per turn, when you use a spell of 1st level or higher to kill at least one creature, you may regain lost hit points up to twice the level of the spell used. If the spell in question belongs to the necromancy school, you may instead regain hit points up to three times the level of the spell. This ability is not triggered by killing creatures without a life force, namely constructs and the undead.",
+    "document": "open5e",
+    "name": "Dark Reaper",
+    "parent": "open5e_school-of-necrotic-arts"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "open5e_school-of-necrotic-arts_dark-reaper"
+},
+{
+  "fields": {
+    "desc": "Starting at 2nd level when you choose this school, you only need to spend half as much time and gold as normal in order to copy a spell into your spellbook if the spell is from the abjuration school.",
+    "document": "open5e",
+    "name": "Expert Necromancer",
+    "parent": "open5e_school-of-necrotic-arts"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "open5e_school-of-necrotic-arts_expert-necromancer"
+},
+{
+  "fields": {
+    "desc": "At 10th level, your familiarity with the necrotic arts has hardened you against some of their effects. You gain resistance against necrotic damage, and your hit point maximum can never be reduced.",
+    "document": "open5e",
+    "name": "Necrotic Acclimation",
+    "parent": "open5e_school-of-necrotic-arts"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "open5e_school-of-necrotic-arts_necrotic-acclimation"
+},
+{
+  "fields": {
+    "desc": "When you reach 6th level, if you do not already know the spell *animate dead*, you add it to your spell book. When you cast this spell, you may target one more pile of bones or corpse than specified by the spell’s description, creating an additional minion of the appropriate type.\n\nIn addition, any undead you create with a spell from the necromancy school gains the following benefits:\n\n* Increase the creature’s hit point maximum by a number equal to your wizard class levels.\n* When making weapon damage rolls, the creature adds your proficiency bonus to the total.",
+    "document": "open5e",
+    "name": "Undead Minions",
+    "parent": "open5e_school-of-necrotic-arts"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "open5e_school-of-necrotic-arts_undead-minions"
+},
+{
+  "fields": {
     "desc": "When you choose this domain at 1st level, you gain proficiency with heavy armor as well as with martial weapons.",
     "document": "open5e",
     "name": "Bonus Proficiency",

--- a/data/v2/open5e/open5e/ClassFeatureItem.json
+++ b/data/v2/open5e/open5e/ClassFeatureItem.json
@@ -463,6 +463,56 @@
   "fields": {
     "column_value": null,
     "detail": null,
+    "level": 14,
+    "parent": "open5e_school-of-necrotic-arts_control-undead"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "open5e_school-of-necrotic-arts_control-undead_14"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 2,
+    "parent": "open5e_school-of-necrotic-arts_dark-reaper"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "open5e_school-of-necrotic-arts_dark-reaper_2"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 2,
+    "parent": "open5e_school-of-necrotic-arts_expert-necromancer"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "open5e_school-of-necrotic-arts_expert-necromancer_2"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 10,
+    "parent": "open5e_school-of-necrotic-arts_necrotic-acclimation"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "open5e_school-of-necrotic-arts_necrotic-acclimation_10"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 6,
+    "parent": "open5e_school-of-necrotic-arts_undead-minions"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "open5e_school-of-necrotic-arts_undead-minions_6"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
     "level": 1,
     "parent": "open5e_storm-domain_bonus-proficiency"
   },


### PR DESCRIPTION
…803)

* remove Restriction from Gravebinder description

this already exists as a class feature

* fix Legionary class features

* fix Legionary class features

* add desc fields from v1, L-R

* add desc fields from v1, S-W

* condense Soulspy spellcasting

due to the headers, this feature was divided into several across a few levels, but this should really be one feature for readability on the subclass page

* condense Soulspy spellcasting

* remove Domain Spells from Portal Domain description

* add various Domain Spells class features

due to formatting it looks like all Domain Spells features for Cleric subclasses in ToH were missed

* add various Domain Spells class features

* add School of Necrotic Arts to V2

this was previously added in V1 only

* add School of Necrotic Arts to V2

* add School of Necrotic Arts to V2